### PR TITLE
Allow passing additional command line options to pt-online-schema-change

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ The extension supports the following java system properties:
     the change will be executed by the default liquibase core implementation and *percona toolkit won't be used*.
     By default, this property is empty, so that all supported changes are executed using the percona toolkit.
     Example: Set this to `addColumn,dropColumn` in order to not use percona for adding/dropping a column.
+    
+*   `liquibase.percona.options`: String of options. **Default: <empty>**.
+    This option allows the user to pass additional command line options to pt-online-schema-change. This e.g. can
+    be used in complication replication setup to change the way salves are detected and how their state is used.
 
 
 You can set these properties by using the standard java `-D` option:

--- a/src/main/java/liquibase/ext/percona/Configuration.java
+++ b/src/main/java/liquibase/ext/percona/Configuration.java
@@ -24,6 +24,8 @@ public final class Configuration {
     public static final String NO_ALTER_SQL_DRY_MODE = "liquibase.percona.noAlterSqlDryMode";
     /** Do not use percona for the given changes, separated by comma. */
     public static final String SKIP_CHANGES = "liquibase.percona.skipChanges";
+    /** Additional command line options that are passed to pt-online-schema-change. */
+    public static final String ADDITIONAL_OPTIONS = "liquibase.percona.options";
 
     public static boolean failIfNoPT() {
         return Boolean.getBoolean(FAIL_IF_NO_PT);
@@ -35,5 +37,9 @@ public final class Configuration {
 
     public static boolean skipChange(String change) {
         return System.getProperty(SKIP_CHANGES, "").contains(change);
+    }
+
+    public static String getAdditionalOptions() {
+        return System.getProperty(ADDITIONAL_OPTIONS, "");
     }
 }

--- a/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
+++ b/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
@@ -57,11 +57,12 @@ public class PTOnlineSchemaChangeStatement extends RuntimeStatement {
     List<String> buildCommand(Database database) {
         List<String> commands = new ArrayList<String>();
         commands.add(PTOnlineSchemaChangeStatement.COMMAND);
-        commands.add("--alter=" + alterStatement);
-        commands.add("--alter-foreign-keys-method=auto");
 
         if (!Configuration.getAdditionalOptions().isEmpty())
             commands.add(Configuration.getAdditionalOptions());
+
+        commands.add("--alter=" + alterStatement);
+        commands.add("--alter-foreign-keys-method=auto");
 
         if (database.getConnection() != null) {
             DatabaseConnectionUtil connection = new DatabaseConnectionUtil(database.getConnection());

--- a/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
+++ b/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
@@ -60,6 +60,9 @@ public class PTOnlineSchemaChangeStatement extends RuntimeStatement {
         commands.add("--alter=" + alterStatement);
         commands.add("--alter-foreign-keys-method=auto");
 
+        if (!Configuration.getAdditionalOptions().isEmpty())
+            commands.add(Configuration.getAdditionalOptions());
+
         if (database.getConnection() != null) {
             DatabaseConnectionUtil connection = new DatabaseConnectionUtil(database.getConnection());
             commands.add("--host=" + connection.getHost());


### PR DESCRIPTION
We needed this since in our somewhat complicated slave and replication setup to change the bahaviour of pt-online-schema-change so it works correctly.

This may also be handy for other circumstances.