### PR TITLE
Support afterColum attribute

### DIFF
--- a/src/main/java/liquibase/ext/percona/PerconaAddColumnChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaAddColumnChange.java
@@ -84,11 +84,16 @@ public class PerconaAddColumnChange extends AddColumnChange {
         if (column.getRemarks() != null) {
             comment += " COMMENT '" + column.getRemarks() + "'";
         }
+        String after = "";
+        if (column.getAfterColumn() != null) {
+            comment += " AFTER " + database.escapeColumnName(null, null, null, column.getAfterColumn());
+        }
         return "ADD COLUMN " + database.escapeColumnName(null, null, null, column.getName())
                 + " " + DataTypeFactory.getInstance().fromDescription(column.getType(), database).toDatabaseDataType(database)
                 + nullable
                 + defaultValue
-                + comment;
+                + comment
+                + after;
     }
 
     @Override


### PR DESCRIPTION
According to http://www.liquibase.org/documentation/column.html liquibase supports an afterColumn-attribute to specify after which column a new column in inserted. However this is not currently supported by liquibase-percona. This PR adds this support.