### PR TITLE
liquibase '*SQL' commands were printing uncommented SQL alters when...

### DIFF
--- a/src/main/java/liquibase/ext/percona/PerconaChangeUtil.java
+++ b/src/main/java/liquibase/ext/percona/PerconaChangeUtil.java
@@ -80,14 +80,8 @@ public class PerconaChangeUtil {
 
                 if (isDryRun(database)) {
                     CommentStatement commentStatement = new CommentStatement(statement.printCommand(database));
-
-                    if (Configuration.noAlterSqlDryMode()) {
-                        statements.clear();
-                        statements.add(0, commentStatement);
-                    } else {
-                        statements.add(0, commentStatement);
-                        statements.add(1, new CommentStatement("Instead of the following statements, pt-online-schema-change will be used"));
-                    }
+                    statements.clear();
+                    statements.add(commentStatement);
                 } else {
                     statements.clear();
                     statements.add(statement);

--- a/src/test/java/liquibase/ext/percona/PerconaAddColumnChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaAddColumnChangeTest.java
@@ -93,14 +93,12 @@ public class PerconaAddColumnChangeTest extends AbstractPerconaChangeTest<Percon
         enableLogging();
 
         SqlStatement[] statements = generateStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"ADD COLUMN new_column INT NULL\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=person",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(AddColumnStatement.class, statements[2].getClass());
     }
 
     @Test
@@ -108,14 +106,12 @@ public class PerconaAddColumnChangeTest extends AbstractPerconaChangeTest<Percon
         enableLogging();
 
         SqlStatement[] statements = generateRollbackStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"DROP COLUMN new_column\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=person",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(DropColumnStatement.class, statements[2].getClass());
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaAddForeignKeyConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaAddForeignKeyConstraintChangeTest.java
@@ -100,14 +100,12 @@ public class PerconaAddForeignKeyConstraintChangeTest extends AbstractPerconaCha
         enableLogging();
 
         SqlStatement[] statements = generateStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"" + alterText + "\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=address",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(AddForeignKeyConstraintStatement.class, statements[2].getClass());
     }
 
     @Test
@@ -115,14 +113,12 @@ public class PerconaAddForeignKeyConstraintChangeTest extends AbstractPerconaCha
         enableLogging();
 
         SqlStatement[] statements = generateRollbackStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"" + alterRollbackText + "\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=address",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(DropForeignKeyConstraintStatement.class, statements[2].getClass());
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaAddUniqueConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaAddUniqueConstraintChangeTest.java
@@ -91,14 +91,12 @@ public class PerconaAddUniqueConstraintChangeTest extends AbstractPerconaChangeT
         enableLogging();
 
         SqlStatement[] statements = generateStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"" + alterText + "\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=person",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(AddUniqueConstraintStatement.class, statements[2].getClass());
     }
 
     @Test
@@ -106,14 +104,12 @@ public class PerconaAddUniqueConstraintChangeTest extends AbstractPerconaChangeT
         enableLogging();
 
         SqlStatement[] statements = generateRollbackStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"" + alterRollbackText + "\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=person",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(DropUniqueConstraintStatement.class, statements[2].getClass());
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaCreateIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaCreateIndexChangeTest.java
@@ -73,14 +73,12 @@ public class PerconaCreateIndexChangeTest extends AbstractPerconaChangeTest<Perc
         enableLogging();
 
         SqlStatement[] statements = generateStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"ADD UNIQUE INDEX theIndexName (indexedColumn)\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=person",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(CreateIndexStatement.class, statements[2].getClass());
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaDropColumnChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaDropColumnChangeTest.java
@@ -78,14 +78,12 @@ public class PerconaDropColumnChangeTest extends AbstractPerconaChangeTest<Perco
         enableLogging();
 
         SqlStatement[] statements = generateStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"DROP COLUMN col_test\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=person",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(DropColumnStatement.class, statements[2].getClass());
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaDropForeignKeyConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaDropForeignKeyConstraintChangeTest.java
@@ -64,14 +64,12 @@ public class PerconaDropForeignKeyConstraintChangeTest extends AbstractPerconaCh
         enableLogging();
 
         SqlStatement[] statements = generateStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"" + alterText + "\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=address",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(DropForeignKeyConstraintStatement.class, statements[2].getClass());
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaDropUniqueConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaDropUniqueConstraintChangeTest.java
@@ -63,14 +63,12 @@ public class PerconaDropUniqueConstraintChangeTest extends AbstractPerconaChange
         enableLogging();
 
         SqlStatement[] statements = generateStatements();
-        Assert.assertEquals(3, statements.length);
+        Assert.assertEquals(1, statements.length);
         Assert.assertEquals(CommentStatement.class, statements[0].getClass());
         Assert.assertEquals("pt-online-schema-change --alter=\"" + alterText + "\" "
                 + "--alter-foreign-keys-method=auto "
                 + "--host=localhost --port=3306 --user=user --password=*** --execute D=testdb,t=person",
                 ((CommentStatement)statements[0]).getText());
-        Assert.assertEquals(CommentStatement.class, statements[1].getClass());
-        Assert.assertEquals(DropUniqueConstraintStatement.class, statements[2].getClass());
     }
 
     @Test


### PR DESCRIPTION
liquibase '*SQL' commands (The commands that output SQL for an update/rollback etc, instead of running the changes) were printing uncommented SQL alters for changesets where pt-online-schema-change would be used.

This change is so if pt-online-schema-change would be used for a changeset, the 'alter' is not printed. An alternative may be to make the alter SQL a comment if this isn't workable.

Does this change make sense @adangel? Am I overlooking anything? Everything seems to work as intended for my use cases. 